### PR TITLE
Bump parent pom and Jenkins required version to fix the build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.43</version>
+        <version>4.33</version>
         <relativePath />
     </parent>
 
@@ -18,7 +18,7 @@
     <url>https://wiki.jenkins-ci.org/display/JENKINS/PostgreSQL+API+Plugin</url>
 
     <properties>
-        <jenkins.version>2.89.4</jenkins.version>
+        <jenkins.version>2.277.1</jenkins.version>
         <java.level>8</java.level>
     </properties>
     <dependencies>


### PR DESCRIPTION
Bump parent pom and Jenkins required version to fix the build.

Buil failed with recent parent pom and Jenkins 2.89.x so I bumped Jenkins requirement.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
